### PR TITLE
Add card rarity information to the card buffer

### DIFF
--- a/src/main/java/sayTheSpire/CardBuffer.java
+++ b/src/main/java/sayTheSpire/CardBuffer.java
@@ -63,7 +63,14 @@ public class CardBuffer extends Buffer {
     }
     this.add(card.name);
     this.add(CardUtils.getCardCostString(card) + " energy");
-    this.add(CardUtils.getCardTypeString(card) + " type");
+    // add card type and rarity as one buffer item.
+    String typeAndRarity = CardUtils.getCardTypeString(card) +" type";
+    String rarity = CardUtils.getCardRarityString(card);
+    // not sure if rarity info can be missing so better check for it
+    if (rarity != null) {
+      typeAndRarity += ", " +rarity  +" rarity";
+    }
+    this.add(typeAndRarity);
     this.add(CardUtils.getCardDescriptionString(card));
     for (String keyword : card.keywords) {
       String name = TextParser.parse(keyword);

--- a/src/main/java/sayTheSpire/utils/CardUtils.java
+++ b/src/main/java/sayTheSpire/utils/CardUtils.java
@@ -75,6 +75,15 @@ public class CardUtils {
         // localizations)
     }
   }
+  
+  public static String getCardRarityString(AbstractCard card) {
+    AbstractCard.CardRarity rarity = card.rarity;
+    // not sure if this can be null so better check it.
+    if (rarity == null) {
+      return null;
+    }
+    return rarity.name().toLowerCase();
+  }
 
   public static String getCardShort(AbstractCard card) {
     if (card.isLocked) {


### PR DESCRIPTION
I thought that it would be useful if information about card rarity (common, uncommon, rare etc.) would be available from the card buffer. However since this information is not often needed, adding it to its own item seemed unnecessary, so I added it to the same item which contained the card type. So now instead of for example "Attack type", it now contains "Attack type, uncommon rarity". I did this by adding a new getCardRarityString method to the CardUtils class and I modified the update method of CardBuffer to add the rarity information to the buffer. The rarity name is now just name of the CardRarity enum value. I don't know if there could be a way to get a localized string for the rarity if the game has that.