### PR TITLE
Fix a bug where some cards' dynamic variables are left unparsed when the game language is set to Japanese

### DIFF
--- a/src/main/java/sayTheSpire/utils/CardUtils.java
+++ b/src/main/java/sayTheSpire/utils/CardUtils.java
@@ -20,7 +20,7 @@ public class CardUtils {
   }
 
   public static String getCardDescriptionString(AbstractCard card) {
-    return TextParser.parse(card.rawDescription, card);
+    return TextParser.parse(card.rawDescription.replaceAll("([^ ])(![A-Z]!)", "$1 $2"), card); // Ensures that dynamic variables have a preceding white space
   }
 
   public static HashMap<String, String> getCardDynamicVariables(AbstractCard card) {


### PR DESCRIPTION
It was occurring for the second wind card for example. (probably same is applicable for other Japanese cards)
The second wind card's rawDescription is like this:
(some Japanese letter letter letter letter)x!B!(Japanese letter letter letter continues)
Since Japanese letters do not have white spaces, reading by word gets the whole string, resulting in the !B! in the middle is not extracted correctly.
I've inserted a regexp replace to make sure that the dynamic variables always have a preceding white space. Since the second wind card had a white space after the variable, I assumed that others also had one as well, so did not do anything about the right side of the variable.
All cards which were successfully parsed until now has surrounding white spaces, so the regexp I added does not match with them. For this reason, I don't think my change breaks the previous behavior.
This PR's base branch is beta2. It will be merged to beta2.