### PR TITLE
speech dispatcher support on linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>speechd</groupId>
+            <artifactId>speechd</artifactId>
+            <version>unknown</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.moandjiezana.toml</groupId>
             <artifactId>toml4j</artifactId>
             <version>0.7.2</version>
@@ -74,6 +80,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.davykager.tolk</include>
+                                    <include>speechd</include>
                                     <include>com.moandjiezana.toml</include>
 <include>org.bigtesting:interpolatd</include>
                                 </includes>

--- a/src/main/java/sayTheSpire/speech/SpeechManager.java
+++ b/src/main/java/sayTheSpire/speech/SpeechManager.java
@@ -20,6 +20,7 @@ public class SpeechManager {
     private void addHandlers() {
         this.registerHandler(new TolkResourceHandler());
         this.registerHandler(new TolkHandler());
+        this.registerHandler(new SpeechdHandler());
         this.registerHandler(new ClipboardHandler());
     }
 

--- a/src/main/java/sayTheSpire/speech/SpeechdHandler.java
+++ b/src/main/java/sayTheSpire/speech/SpeechdHandler.java
@@ -1,0 +1,82 @@
+package sayTheSpire.speech;
+
+import speechd.ssip.SSIPException;
+import speechd.ssip.SSIPClient;
+import speechd.ssip.SSIPPriority;
+import sayTheSpire.Output;
+
+public class SpeechdHandler extends SpeechHandler {
+
+    SSIPClient spd = null;
+
+    public SpeechdHandler() {
+        super();
+        this.setName("speech-dispatcher");
+    }
+
+    public Boolean detect() {
+        return System.getProperty("os.name").startsWith("Linux");
+    }
+
+    public void disposeResources() {
+        // do nothing
+    }
+
+    public Boolean loadResources() {
+        return true; // do nothing
+    }
+
+    public Boolean load() {
+        try {
+            spd = new SSIPClient("sayTheSpire", null, null);
+        } catch (SSIPException e) {
+            return false;
+        }
+        return true;
+    }
+
+    public Boolean output(String text, Boolean interrupt) {
+        try {
+            if (interrupt == true) {
+                spd.say(SSIPPriority.IMPORTANT, text);
+            } else {
+                spd.say(SSIPPriority.MESSAGE, text);
+            }
+        } catch (SSIPException e) {
+            return false;
+        }
+        return true;
+    }
+
+    public Boolean silence() {
+        try {
+            spd.stop();
+        } catch (SSIPException e) {
+            return false;
+        }
+        return true;
+    }
+
+    public Boolean speak(String text, Boolean interrupt) {
+        try {
+            if (interrupt == true) {
+                spd.say(SSIPPriority.IMPORTANT, text);
+            } else {
+                spd.say(SSIPPriority.MESSAGE, text);
+            }
+        } catch (SSIPException e) {
+            return false;
+        }
+        return true;
+    }
+
+    public void unload() {
+        try {
+            spd.close();
+        } catch (SSIPException e) {
+            spd = null;
+            return;
+        }
+        spd = null;
+    }
+}


### PR DESCRIPTION
I added basic speech dispatcher support for linux, after realizing that clipboard events were getting lost when the mod sent text in rapid succession -- unfortunately, the clipboard is not an rpc even if used as such. Unfortunately the java bindings for speech dispatcher are very, very old, so only support tcp sockets, thus you must do something like the following before starting ModTheSpire:

```
speech-dispatcher -c inet_socket -t 0 -P "$HOME/.local/share/speechd.pid"
```

I'd love help updating the docs about compiling -- the mod now needs  speechd.jar from https://github.com/brailcom/speechd-java. Also the documentation needs to be updated about the required speech-dispatcher line on linux when using speech-dispatcher. I would do these things, but I'm not exactly sure how the docs work so if you wouldn't mind updating them, that would be great.

-Michael.

